### PR TITLE
feat: add more predicates for nvim-treesitter parity

### DIFF
--- a/highlights.lua
+++ b/highlights.lua
@@ -71,12 +71,16 @@ M.addPredicate('has-ancestor?', function(t, ...)
 
 	return false
 end)
-M.addPredicate('has-parent?', function(t, type)
+M.addPredicate('has-parent?', function(t, ...)
 	local c = t:create_cursor()
 	c:goto_parent()
 
 	local n = c:current_node()
-	return n:type() == type
+	for _, typ in ipairs {...} do
+		if n:type() == typ then return true end
+	end
+
+	return false
 end)
 
 --- @param doc core.doc

--- a/init.lua
+++ b/init.lua
@@ -213,14 +213,14 @@ function Highlight:tokenize_line(idx, state)
 	}) do
 		local startPoint = n:start_point()
 		local endPoint = n:end_point()
-
 		if i > endPoint.row then goto continue end
 		if i < startPoint.row then break end
+		-- print(i, n, n:source(), startPoint.column + 1, endPoint.column + 1)
 
 		if not lastNode and startPoint.column > 0 and i == startPoint.row then
 			-- first node
-				tokens[#tokens + 1] = 'normal'
-				tokens[#tokens + 1] = currentLine:sub(1, startPoint.column)
+			tokens[#tokens + 1] = 'normal'
+			tokens[#tokens + 1] = currentLine:sub(1, startPoint.column)
 		elseif lastNode and lastEndPoint.row == startPoint.row and startPoint.column - lastEndPoint.column > 0 then
 			tokens[#tokens + 1] = 'normal'
 			tokens[#tokens + 1] = currentLine:sub(lastEndPoint.column + 1, startPoint.column)
@@ -260,6 +260,15 @@ function Highlight:tokenize_line(idx, state)
 			end
 		end
 
+		if lastEndPoint and lastEndPoint.column > endPoint.column then
+			-- print("THIS IS WEIRD")
+			local prevGroup, prevSource = tokens[#tokens - 1], tokens[#tokens]
+			tokens[#tokens - 1] = 'normal'
+			tokens[#tokens] = currentLine:sub(lastStartPoint.column + 1, startPoint.column)
+			tokens[#tokens + 1] = prevGroup
+			tokens[#tokens + 1] = prevSource
+		end
+
 		lastNode = n
 		lastName = nName
 		lastStartPoint = startPoint
@@ -278,6 +287,7 @@ function Highlight:tokenize_line(idx, state)
 		tokens[#tokens+1] = currentLine
 	end
 
+	print(i, common.serialize(tokens))
 	return res
 end
 

--- a/init.lua
+++ b/init.lua
@@ -287,7 +287,6 @@ function Highlight:tokenize_line(idx, state)
 		tokens[#tokens+1] = currentLine
 	end
 
-	print(i, common.serialize(tokens))
 	return res
 end
 

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -121,7 +121,14 @@
 
 (preproc_defined) @function.macro
 
+(((field_expression
+     (field_identifier) @property)) @_parent
+ (#not-has-parent? @_parent template_method function_declarator call_expression))
+
 (field_designator) @property
+(((field_identifier) @property)
+ (#has-ancestor? @property field_declaration)
+ (#not-has-ancestor? @property function_declarator))
 
 (statement_identifier) @label
 
@@ -193,6 +200,9 @@
 ((call_expression
   function: (identifier) @function.builtin)
   (#lua-match? @function.builtin "^__builtin_"))
+((call_expression
+   function: (identifier) @function.builtin)
+  (#has-ancestor? @function.builtin attribute_specifier))
 
 ;; Preproc def / undef
 (preproc_def
@@ -216,7 +226,7 @@
 (preproc_function_def
   name: (identifier) @function.macro)
 
-(comment) @comment @spell
+(comment) @comment
 
 ((comment) @comment.documentation
   (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -216,7 +216,7 @@
 (preproc_function_def
   name: (identifier) @function.macro)
 
-(comment) @comment @spell
+(comment) @comment
 
 ((comment) @comment.documentation
   (#lua-match? @comment.documentation "^/[*][*][^*].*[*]/$"))
@@ -263,6 +263,10 @@
 
 ;(field_expression) @parameter ;; How to highlight this?
 
+(((field_expression
+     (field_identifier) @method)) @_parent
+ (#has-parent? @_parent template_method function_declarator))
+
 (field_declaration
   (field_identifier) @field)
 
@@ -305,6 +309,12 @@
     (qualified_identifier
       (qualified_identifier
         (identifier) @function))))
+((qualified_identifier
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function)))) @_parent
+  (#has-ancestor? @_parent function_declarator))
 
 (function_declarator
   (template_function
@@ -326,6 +336,12 @@
     (qualified_identifier
       (qualified_identifier
         (identifier) @function.call))))
+((qualified_identifier
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function.call)))) @_parent
+  (#has-ancestor? @_parent call_expression))
 
 (call_expression
   (template_function
@@ -345,6 +361,13 @@
       (qualified_identifier
         (template_function
           (identifier) @function.call)))))
+((qualified_identifier
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (template_function
+          (identifier) @function.call))))) @_parent
+  (#has-ancestor? @_parent call_expression))
 
 ; methods
 (function_declarator
@@ -462,5 +485,3 @@
   ["<" ">"] @punctuation.bracket)
 
 (literal_suffix) @operator
-
-(ERROR) @error

--- a/queries/go/highlights.scm
+++ b/queries/go/highlights.scm
@@ -41,10 +41,10 @@
 ; Constructors
 
 ((call_expression (identifier) @constructor)
-  (#lua-match? @constructor "^[nN]ew.*$"))
+  (#lua-match? @constructor "^[nN]ew.+$"))
 
 ((call_expression (identifier) @constructor)
-  (#lua-match? @constructor "^[mM]ake.*$"))
+  (#lua-match? @constructor "^[mM]ake.+$"))
 
 ; Operators
 

--- a/queries/lua/highlights.scm
+++ b/queries/lua/highlights.scm
@@ -2,13 +2,13 @@
 
 "return" @keyword.return
 
+(label_statement) @label
+
 [
  "goto"
  "in"
  "local"
 ] @keyword
-
-(label_statement) @label
 
 (break_statement) @keyword
 


### PR DESCRIPTION
@xcb-xwii review, you should also use this for your pr

i had this in working for a while, so i'd rather merge now

this pr adds the following predicates:
- `has-parent?`
- `has-ancestor?`

and adds `not-*` for all existing predicates