### PR TITLE
feat: switch to `lua-tree-sitter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,28 @@ It is work in progress, but functions well.
 If you want more languages supported, open an issue.
 
 # Requirements
-- Lite XL 2.1+ or [Pragtical](https://github.com/pragtical/pragtical)
-- [ltreesitter](#ltreesitter-installation) (automatic, manually or via LuaRocks)
+- [Lite XL](https://lite-xl.com) 2.1+ or [Pragtical](https://pragtical.dev)
+- `lua_tree_sitter` library
 
-# Install
-## Express Install
+# Installation
+## Plugin Manager
+
+### Miq
 Evergreen can be easily installed with [Miq](https://github.com/TorchedSammy/Miq) by
 adding this to your plugin declaration:
 ```lua
 {'TorchedSammy/Evergreen.lxl'},
 ```
 
-## Manually
+### lpm / ppm
+Evergreen can be installed using [lpm](https://github.com/lite-xl/lite-xl-plugin-manager)
+for Lite XL or [ppm](https://github.com/pragtical/plugin-manager) for Pragtical:
+```
+lpm install evergreen
+ppm install evergreen
+```
+
+## Manual
 - Git clone Evergreen into Lite XL plugins directory
 Or symlink:  
 ```
@@ -51,61 +61,18 @@ git clone https://github.com/TorchedSammy/Evergreen.lxl
 ln -s ~/Downloads/Evergreen.lxl ~/.config/lite-xl/plugins/evergreen
 ```
 
-## ltreesitter Installation
-### Automatic
-The easiest way to install ltreesitter is by not installing it at all!
-Evergreen will automatically download a compatible ltreesitter build and
-reload itself.
+## `lua_tree_sitter` Installation
+### Plugin Manager
 
-If it fails to download for any reason though, that should be reported
-as an issue here. In the mean time, ltreesitter can be installed manually.
+Plugin managers will handle the installation of the `lua_tree_sitter` library
+automatically.
 
 ### Manual Install
-The simplest way to install ltreesitter is to run the following command
-(assuming LuaRocks is installed):
 
-```sh
-luarocks install ltreesitter --local --dev
-```
-
-This may work, but ltreesitter does not officially support Lite XL.
-You may encounter problems when installing it via LuaRocks
-which might return error messages similar to these or cause crashes:
-
-```
-Sat Jun 17 13:36:37 2023 [ERROR] Failed loading /home/user/.luarocks/lib/lua/5.4/ltreesitter.so: /home/user/.luarocks/lib/lua/5.4/ltreesitter.so: undefined symbol: lua_checkstack at /home/user/.local/bin/lite-xl/data/core/init.lua:1226
-
-stack traceback:
-[C]: in function 'system.load_native_plugin'
-[C]: in function 'require'
-...hacuber2a03/.config/lite-xl/plugins/evergreen/parser.lua:2: in main chunk
-[C]: in function 'require'
-.../user/.config/lite-xl/plugins/evergreen/init.lua:21: in main chunk
-[C]: in function 'require'
-[C]: in function 'xpcall'
-/home/user/.local/bin/lite-xl/data/core/init.lua:1225: in function 'core.try'
-/home/user/.local/bin/lite-xl/data/core/init.lua:1013: in function 'core.load_plugins'
-/home/user/.local/bin/lite-xl/data/core/init.lua:793: in function 'core.init'
-[string "local core..."]:8: in function <[string "local core..."]:2>
-[C]: in function 'xpcall'
-[string "local core..."]:2: in main chunk
-```
-
-In that case, you need to install a special version of ltreesitter for Lite XL.
-
-> **Note**
-> You **must** upgrade to the [`master`](https://github.com/lite-xl/lite-xl/tree/master) version of Lite XL.
-
-You can either compile ltreesitter via the command below:
-```sh
-git clone --recursive -b lite-xl-plugin-api https://github.com/takase1121/ltreesitter.git
-cd ltreesitter
-make ltreesitter.so
-cp ltreesitter.so ~/.config/lite-xl/ltreesitter.so
-```
-
-Or download an appropriate release from [here](https://github.com/TorchedSammy/evergreen-builds/releases/tag/ltreesitter),
-where ltreesitter.so is Linux, and ltreesitter.dll is Windows.
+You can download the library from
+[here](https://github.com/xcb-xwii/lite-xl-tree-sitter/releases), and then place
+it inside the `libraries/tree_sitter` directory inside your user directory.
+Rename the binary to `init.so`.
 
 # Usage
 To use Evergreen, you have to install the parser for your language of choice.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+	"addons": [
+		{
+			"id": "evergreen",
+			"description": "🌳 Treesitter support for Lite XL.",
+			"name": "Evergreen.lxl",
+			"mod-version": "3",
+			"version": "0.2",
+			"path": ".",
+			"dependencies": [ "tree_sitter" ]
+		}
+	]
+}

--- a/parser.lua
+++ b/parser.lua
@@ -1,5 +1,5 @@
 local core = require 'core'
-local ltreesitter = require 'ltreesitter'
+local ts = require 'libraries.tree_sitter'
 local M = {
 	_parsers = {}
 }
@@ -8,23 +8,29 @@ function M.get(ftype)
 	if not ftype then return end
 	if M._parsers[ftype] then return M._parsers[ftype] end
 
-	local ok, result = pcall(ltreesitter.require, ftype)
+	local ok, lang = pcall(ts.Language.require, ftype)
+	local parser
 
 	if not ok then
 		core.error(string.format('Could not load parser for %s\n%s', ftype, result))
 		return nil
 	else
 		core.log(string.format('Loaded parser for %s', ftype))
-		M._parsers[ftype] = result
+		parser = ts.Parser.new()
+		parser:set_language(lang)
+		M._parsers[ftype] = parser
 	end
 
-	return result
+	return parser
 end
 
 function M.input(lines)
 	return function(_, point)
-		return (point.row < #lines)
-			and (lines[point.row + 1]:sub(point.column + 1)) or nil
+		if point:row() < #lines then
+			return lines[point:row() + 1], point:column() + 1
+		else
+			return nil
+		end
 	end
 end
 


### PR DESCRIPTION
As `ltreesitter` development seems to have stagnated, I have created new bindings for Tree-sitter. This can be found at https://github.com/xcb-xwii/lua-tree-sitter.
These bindings should be more flexible, and have more complete implementations, so we can move on to completing nvim parity.