### PR TITLE
FIX: style variable declaration typo and missing property

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ These are the available highlight groups:
 - `parameter`: Parameters to a function (in declaration)
 - `preproc`: Preprocessor directives (`#if` in C)
 - `punctuation.delimiter`: Punctuation that delimits items (`,` and `:`)
-- `punctuation.brackets`: Brackets of all kinds (`()` or `{}`, etc)
+- `punctuation.bracket`: Brackets of all kinds (`()` or `{}`, etc)
 - `punctuation.special`: `#` in rust, treated as an operator by default
 - `repeat`: Keywords relating to loops (`while`, `for`)
 - `storageclass`: `static`, `const` in C
@@ -141,6 +141,7 @@ These are the available highlight groups:
 - `type.builtin`: Builtin types (`int`, `bool`)
 - `type.definition`
 - `type.qualifier`: Type qualifiers (`private`, `public`)
+- `property`: class field
 - `variable`
 - `variable.builtin`: Builtin variables (`this`, `self`)
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,12 @@ These are the available highlight groups:
 - `function`: Function declaration
 - `function.call`: Function call
 - `function.macro`
+- `function.builtin`
 - `include`: Keywords related to including modules/packages
 - `keyword.function`: The function operator in a language (like `func` in Go)
 - `keyword.operator`: Operators that are words (like `and`, `or` in Lua)
 - `keyword.return`: The `return` operator
+- `keyword.coroutine`
 - `label`
 - `method`
 - `method.call`
@@ -144,6 +146,7 @@ These are the available highlight groups:
 - `property`: class field
 - `variable`
 - `variable.builtin`: Builtin variables (`this`, `self`)
+- `error`
 
 # License
 MIT

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ These are the available highlight groups:
 - `storageclass`: `static`, `const` in C
 - `storageclass.lifetime`: Specifically for lifetimes in Rust currently
 - `string`
+- `string.escape`: string special character (e.g.: `\n`)
 - `tag`: HTML/JSX tags
 - `tag.delimiter`: <>
 - `tag.attribute`: Tag attributes

--- a/style.lua
+++ b/style.lua
@@ -24,6 +24,9 @@ local altMap = {
 		'number',
 		'label'
 	},
+	string = {
+		'string.escape',
+	},
 	constant = {'constant.builtin'},
 	comment = {
 		'comment.documentation'

--- a/style.lua
+++ b/style.lua
@@ -66,9 +66,10 @@ local altMap = {
 	method = {'method.call'},
 	normal = {
 		'field',
-		'punctuation.brackets',
+		'punctuation.bracket',
 		'punctuation.delimiter',
-		'variable'
+		'variable',
+		'property',
 	},
 	attribute = {
 		'tag.attribute',

--- a/style.lua
+++ b/style.lua
@@ -36,6 +36,7 @@ local altMap = {
 		'include',
 		'keyword.function',
 		'keyword.return',
+		'keyword.coroutine',
 		'namespace',
 		'preproc',
 		'repeat',
@@ -47,6 +48,7 @@ local altMap = {
 		'type.builtin',
 		'variable.builtin',
 		'type.definition',
+		'error',
 	},
 	operator = {
 		'conditional.ternary',
@@ -60,6 +62,7 @@ local altMap = {
 	['function'] = {
 		'function.call',
 		'function.macro',
+		'function.builtin',
 		'method',
 		'tag'
 	},


### PR DESCRIPTION
The styling information in the [README](README.md) is partially wrong (a typo) and is missing at least a class.

The same problems are in the file `style.lua`

For example for the `cpp` queries this are the following missing classes:

```
keyword.coroutine
punctuation.bracket
error
string.escape
property
function.builtin
```

For `punctuation.bracket` is only a typo