### PR TITLE
Avoid nil state

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -173,6 +173,7 @@ function Highlight:tokenize_line(idx, state)
 	local toks     = {}
 	local buf      = { 'normal', #txt }
 	local startBuf = 0
+	state = state or string.char(0)
 
 	local cursor = ts.Query.Cursor.new(self.doc.ts.query, self.doc.ts.tree:root_node())
 	cursor:set_point_range(ts.Point.new(row, 0), ts.Point.new(row, #txt - 1))


### PR DESCRIPTION
I was having problem to `toggle-comments` with `evergreen` enabled due to a incorrect value of the `state` variable. 
By checking what lite-xl is internally doing (`core/tokenizer.lua:142`) it seems that evergreen was missing a simple set to empty string of the `state` variable.

Adding this patch I am now able to comment/uncomment without problems!