### PR TITLE
c/cpp: Fix #undef

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ These are the available highlight groups:
 - `operator`
 - `parameter`: Parameters to a function (in declaration)
 - `preproc`: Preprocessor directives (`#if` in C)
+- `property`: class field
 - `punctuation.delimiter`: Punctuation that delimits items (`,` and `:`)
 - `punctuation.bracket`: Brackets of all kinds (`()` or `{}`, etc)
 - `punctuation.special`: `#` in rust, treated as an operator by default
@@ -144,7 +145,7 @@ These are the available highlight groups:
 - `type.builtin`: Builtin types (`int`, `bool`)
 - `type.definition`
 - `type.qualifier`: Type qualifiers (`private`, `public`)
-- `property`: class field
+- `undefine`
 - `variable`
 - `variable.builtin`: Builtin variables (`this`, `self`)
 - `error`

--- a/queries/c/highlights.scm
+++ b/queries/c/highlights.scm
@@ -198,9 +198,9 @@
 (preproc_def
   name: (_) @constant)
 (preproc_call
-  directive: (preproc_directive) @_u
+  directive: (preproc_directive) @undefine
   argument: (_) @constant
-  (#eq? @_u "#undef"))
+  (#eq? @undefine "#undef"))
 
 (call_expression
   function: (identifier) @function.call)

--- a/queries/cpp/highlights.scm
+++ b/queries/cpp/highlights.scm
@@ -198,9 +198,9 @@
 (preproc_def
   name: (_) @constant)
 (preproc_call
-  directive: (preproc_directive) @_u
+  directive: (preproc_directive) @undefine
   argument: (_) @constant
-  (#eq? @_u "#undef"))
+  (#eq? @undefine "#undef"))
 
 (call_expression
   function: (identifier) @function.call)

--- a/style.lua
+++ b/style.lua
@@ -44,6 +44,7 @@ local altMap = {
 		'preproc',
 		'repeat',
 		'type.qualifier',
+		'undefine',
 		'constructor'
 	},
 	keyword2 = {


### PR DESCRIPTION
Closes #71.

Issue here is `@_u` captures `#undef` thus `@preproc` doesn't pick `#undef` up.

Here we just rename `@_u` to something more user-facing and then document this, which fixes the problem.