### PR TITLE
Split up re-parsing across multiple frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ evergreenConfig.option2 = 1000
 | `useFallbackColors`  | `true`       | set fallbacks for missing colors
 | `warnFallbackColors` | `true`       | warn when fallback colors are used
 | `soExt`              | `.so`/`.dll` | shared library extension (`.dll` on Windows, `.so` otherwise)
+| `maxParseTime`       | `2000`       | maximum time spent parsing before deferring it (in µs). set to 0 to disable deferring
 
 # License
 MIT

--- a/config.lua
+++ b/config.lua
@@ -3,6 +3,7 @@ local common = require 'core.common'
 local M = {
 	useFallbackColors = true,
 	warnFallbackColors = true,
+	maxParseTime = 2000,
 }
 
 if PLATFORM ~= 'Windows' then

--- a/highlights.lua
+++ b/highlights.lua
@@ -1,3 +1,4 @@
+local config = require 'plugins.evergreen.config'
 local languages = require 'plugins.evergreen.languages'
 local util = require 'plugins.evergreen.util'
 local ts = require 'libraries.tree_sitter'
@@ -202,6 +203,8 @@ function M.init(doc)
 		query = query,
 		runner = ts.Query.Runner.new(predicatesFor(doc)),
 	}
+
+	parser:set_timeout_micros(config.maxParseTime)
 end
 
 


### PR DESCRIPTION
- a coroutine runs the parser, with a configurable timeout before deferring to the next coroutine run
  - this prevents stuttering when typing quickly on enormous documents, albeit at the expense of highlighting only updating when one slows down or stops
  - however, the reparsing is attempted once immediately after each input, so if the doc is short enough to complete parsing before timing out, the rehighlighting can still be instant
- replace the default lxl highlighter
  - new highlighter does not attempt to parse all the lines before the last needed line
  - as such, after each successful parse we can just nuke all the lines to rehighlight all of them, instead of trying to figure out which lines need rehilighting (predicates made this complicated)
- if for whatever reason the old behaviour is still needed the timeout can just be set to 0